### PR TITLE
feat: add VoiceClonePrompt helper methods for embedding save/load

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,15 @@ pub struct VoiceClonePrompt {
     pub ref_text_ids: Option<Vec<u32>>,
 }
 
+impl VoiceClonePrompt {
+    /// Get the speaker embedding as a flat vector of f32 values.
+    ///
+    /// Useful for saving/loading embeddings to disk.
+    pub fn get_embedding_vec(&self) -> Result<Vec<f32>> {
+        Ok(self.speaker_embedding.flatten_all()?.to_vec1()?)
+    }
+}
+
 /// Per-stage timing breakdown from a synthesis run.
 #[derive(Debug, Clone, Serialize)]
 pub struct SynthesisTiming {
@@ -1189,6 +1198,28 @@ impl Qwen3TTS {
             speaker_embedding,
             ref_codes,
             ref_text_ids,
+        })
+    }
+
+    /// Create a voice clone prompt from a pre-computed speaker embedding.
+    ///
+    /// This is useful for reusing saved embeddings without re-encoding reference audio.
+    /// The embedding should be a 1D tensor with shape `[enc_dim]` (typically 1024).
+    pub fn create_voice_clone_prompt_from_embedding(
+        &self,
+        speaker_embedding: Tensor,
+    ) -> Result<VoiceClonePrompt> {
+        if !self.supports_voice_cloning() {
+            anyhow::bail!(
+                "Voice cloning requires a Base model with a speaker encoder. \
+                 Current model does not support voice cloning."
+            );
+        }
+
+        Ok(VoiceClonePrompt {
+            speaker_embedding,
+            ref_codes: None,
+            ref_text_ids: None,
         })
     }
 


### PR DESCRIPTION
## Summary

Adds helper methods to `VoiceClonePrompt` for easier speaker embedding management:

- `get_embedding_vec()` - Extract embedding as `Vec<f32>` for serialization
- `create_voice_clone_prompt_from_embedding()` - Create prompt from pre-computed embedding

This enables voice library functionality where embeddings can be saved to disk and loaded later without re-encoding reference audio.

## Usage Example

```rust
// Create prompt from reference audio
let ref_audio = AudioBuffer::load("voice.wav")?;
let prompt = tts.create_voice_clone_prompt(&ref_audio, None)?;

// Save embedding for later
let embedding = prompt.get_embedding_vec()?;
std::fs::write("voice.bin", bytemuck::cast_slice(&embedding))?;

// Later: load embedding without re-encoding
let bytes = std::fs::read("voice.bin")?;
let embedding: Vec<f32> = bytes.chunks_exact(4)
    .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
    .collect();
let embedding_tensor = Tensor::from_vec(embedding, (len,), device)?;
let prompt = tts.create_voice_clone_prompt_from_embedding(embedding_tensor)?;
```

## Testing

This is used in [jack-voice](https://github.com/dusterbloom/jack-voice) for the voice library feature.